### PR TITLE
Fixed  entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ All notable changes to `@todovue/tv-demo` will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
-    ## [1.0.4] - 2025-09-05
-    
-    ### 🛠️ Changed
-    - Fixed the library entry point in `vite.config.js` to point to `src/entry.ts` instead of the `.vue` file. This resolves the default import error from Vue (`No matching export in "vue" for import "default"`) and ensures full compatibility with Vue 3 in both SPA and SSR (Nuxt 3).
+## [1.0.4] - 2025-09-05
+
+### 🛠️ Changed
+- Fixed the library entry point in `vite.config.js` to point to `src/entry.ts` instead of the `.vue` file. This resolves the default import error from Vue (`No matching export in "vue" for import "default"`) and ensures full compatibility with Vue 3 in both SPA and SSR (Nuxt 3).
 
 ---
 ## [1.0.3] - 2025-09-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to `@todovue/tv-demo` will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
+## [1.0.4] - 2025-09-05
+
+### 🛠️ Changed
+- Fixed the library entry point in `vite.config.js` to point to `src/entry.ts` instead of the `.vue` file. This resolves the default import error from Vue (`No matching export in "vue" for import "default"`) and ensures full compatibility with Vue 3 in both SPA and SSR (Nuxt 3).
+
+---
 ## [1.0.3] - 2025-09-05
 
 ### ✨ Added
@@ -48,6 +54,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Responsive layout for desktop and mobile screens.
 
 ---
+[1.0.4]: https://github.com/TODOvue/tv-demo/pull/22/files
 [1.0.3]: https://github.com/TODOvue/tv-demo/pull/21/files
 [1.0.2]: https://github.com/TODOvue/tv-demo/pull/20/files
 [1.0.1]: https://github.com/TODOvue/tv-demo/pull/19/files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ All notable changes to `@todovue/tv-demo` will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
-## [1.0.4] - 2025-09-05
-
-### 🛠️ Changed
-- Fixed the library entry point in `vite.config.js` to point to `src/entry.ts` instead of the `.vue` file. This resolves the default import error from Vue (`No matching export in "vue" for import "default"`) and ensures full compatibility with Vue 3 in both SPA and SSR (Nuxt 3).
+    ## [1.0.4] - 2025-09-05
+    
+    ### 🛠️ Changed
+    - Fixed the library entry point in `vite.config.js` to point to `src/entry.ts` instead of the `.vue` file. This resolves the default import error from Vue (`No matching export in "vue" for import "default"`) and ensures full compatibility with Vue 3 in both SPA and SSR (Nuxt 3).
 
 ---
 ## [1.0.3] - 2025-09-05

--- a/src/demo/Demo.vue
+++ b/src/demo/Demo.vue
@@ -17,7 +17,7 @@ const Component = defineAsyncComponent(/* webpackChunkName: "Test" */() => impor
     sourceLink="https://github.com/TODOvue/tv-demo"
     urlClone="https://github.com/TODOvue/tv-demo.git"
     is-dev-component
-    version="1.0.3"
+    version="1.0.4"
   ></tv-demo>
 </template>
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -20,7 +20,7 @@ export default defineConfig({
     }
     : {
       lib: {
-        entry: "src/components/TvDemo.vue",
+        entry: "src/entry.ts",
         name: "TvDemo",
         fileName: format => `tv-demo.${format}.js`,
         formats: ["es", "cjs"]


### PR DESCRIPTION
## [1.0.4] - 2025-09-05

### 🛠️ Changed
- Fixed the library entry point in `vite.config.js` to point to `src/entry.ts` instead of the `.vue` file. This resolves the default import error from Vue (`No matching export in "vue" for import "default"`) and ensures full compatibility with Vue 3 in both SPA and SSR (Nuxt 3).
