### PR TITLE
 Moved dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to `@todovue/tv-demo` will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
+## [1.0.6] - 2025-09-06
+
+### 🛠️ Changed
+- Moved `vue-highlight-code` and `vue3-markdown-it` to `peerDependencies` to avoid internal bundling that could trigger interop / synthetic default Vue imports in pre-bundling environments (esbuild / Vite optimizeDeps).
+- Added `verify:dist` script that ensures the bundle does not contain `import <default> from 'vue'` nor mixed default + named imports.
+
+### 🐛 Fixed
+- Additional mitigation for the error: `No matching export in "vue" for import "default"` in SPA consumers by guaranteeing only named imports and properly externalized dependencies.
+
+---
 ## [1.0.5] - 2025-09-05
 
 ### 🐛 Fixed
@@ -66,6 +76,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Responsive layout for desktop and mobile screens.
 
 ---
+[1.0.6]: https://github.com/TODOvue/tv-demo/pull/24/files
 [1.0.5]: https://github.com/TODOvue/tv-demo/pull/23/files
 [1.0.4]: https://github.com/TODOvue/tv-demo/pull/22/files
 [1.0.3]: https://github.com/TODOvue/tv-demo/pull/21/files

--- a/package.json
+++ b/package.json
@@ -45,21 +45,24 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "build:demo": "cp README.md public/ && VITE_BUILD_TARGET=demo vite build"
+    "build:demo": "cp README.md public/ && VITE_BUILD_TARGET=demo vite build",
+    "verify:dist": "node scripts/verify-dist.mjs"
   },
   "peerDependencies": {
-    "vue": "^3.0.0"
-  },
-  "dependencies": {
-    "github-markdown-css": "^5.0.0",
+    "vue": "^3.0.0",
     "vue-highlight-code": "^0.2.0",
     "vue3-markdown-it": "^1.0.0"
+  },
+  "dependencies": {
+    "github-markdown-css": "^5.0.0"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.0",
     "sass": "^1.0.0",
     "vite": "^7.0.0",
     "vite-plugin-css-injected-by-js": "^3.0.0",
-    "vite-plugin-dts": "^4.0.0"
+    "vite-plugin-dts": "^4.0.0",
+    "vue-highlight-code": "^0.2.0",
+    "vue3-markdown-it": "^1.0.0"
   }
 }

--- a/scripts/verify-dist.mjs
+++ b/scripts/verify-dist.mjs
@@ -12,15 +12,14 @@ for (const f of files) {
   const full = join(distDir, f);
   const content = readFileSync(full, 'utf8');
   if (defaultVuePattern.test(content) || mixedPattern.test(content)) {
-    console.error(`❌ Detectado import default de Vue en: ${f}`);
+    console.error(`❌ Detected default Vue import in: ${f}`);
     hasError = true;
   }
 }
 
 if (hasError) {
-  console.error('Fallo verificación: import default de Vue presente.');
+  console.error('Verification failed: default Vue import present.');
   process.exit(1);
 } else {
-  console.log('✅ Verificación OK: no hay import default de Vue.');
+  console.log('✅ Verification OK: no default Vue import found.');
 }
-

--- a/scripts/verify-dist.mjs
+++ b/scripts/verify-dist.mjs
@@ -1,0 +1,26 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const distDir = join(process.cwd(), 'dist');
+const files = readdirSync(distDir).filter(f => f.endsWith('.js'));
+
+let hasError = false;
+const defaultVuePattern = /import\s+([A-Za-z_$][\w$]*)\s*(,|from)\s*(?:{[^}]*}\s*from\s*)?["']vue["']/;
+const mixedPattern = /import\s+[A-Za-z_$][\w$]*\s*,\s*{[^}]+}\s*from\s*["']vue["']/;
+
+for (const f of files) {
+  const full = join(distDir, f);
+  const content = readFileSync(full, 'utf8');
+  if (defaultVuePattern.test(content) || mixedPattern.test(content)) {
+    console.error(`❌ Detectado import default de Vue en: ${f}`);
+    hasError = true;
+  }
+}
+
+if (hasError) {
+  console.error('Fallo verificación: import default de Vue presente.');
+  process.exit(1);
+} else {
+  console.log('✅ Verificación OK: no hay import default de Vue.');
+}
+

--- a/src/demo/Demo.vue
+++ b/src/demo/Demo.vue
@@ -17,7 +17,7 @@ const Component = defineAsyncComponent(/* webpackChunkName: "Test" */() => impor
     sourceLink="https://github.com/TODOvue/tv-demo"
     urlClone="https://github.com/TODOvue/tv-demo.git"
     is-dev-component
-    version="1.0.4"
+    version="1.0.6"
   ></tv-demo>
 </template>
 


### PR DESCRIPTION
## [1.0.6] - 2025-09-06

### 🛠️ Changed
- Moved `vue-highlight-code` and `vue3-markdown-it` to `peerDependencies` to avoid internal bundling that could trigger interop / synthetic default Vue imports in pre-bundling environments (esbuild / Vite optimizeDeps).
- Added `verify:dist` script that ensures the bundle does not contain `import <default> from 'vue'` nor mixed default + named imports.

### 🐛 Fixed
- Additional mitigation for the error: `No matching export in "vue" for import "default"` in SPA consumers by guaranteeing only named imports and properly externalized dependencies.