### PR TITLE
update tv-demo link colors to inherit for better consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `@todovue/tv-demo` will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.2.1] - 2025-11-21
+
+### Fixed
+- Fixed links color when the component use `hide-background` demo style.
+
 ## [1.2.0] - 2025-11-20
 
 ### Added
@@ -130,6 +135,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Integrated `vue-highlight-code` for live code display.
 - Responsive layout for desktop and mobile screens.
 
+[1.2.1]: https://github.com/TODOvue/tv-demo/pull/35/files
 [1.2.0]: https://github.com/TODOvue/tv-demo/pull/34/files
 [1.1.1]: https://github.com/TODOvue/tv-demo/pull/33/files
 [1.1.0]: https://github.com/TODOvue/tv-demo/pull/32/files

--- a/src/assets/scss/style.scss
+++ b/src/assets/scss/style.scss
@@ -250,9 +250,8 @@
     }
   }
 
-  & .tv-demo-links-item,
-  & a.tv-demo-links-item {
-    color: #60a5fa;
+  & a.tv-demo-links-item, div.tv-demo-links-item {
+    color: inherit;
     text-decoration-color: rgba(96, 165, 250, 0.6);
     text-shadow: 0 0 12px rgba(96, 165, 250, 0.35);
 
@@ -295,9 +294,9 @@
     }
   }
 
-  & .tv-demo-links-item,
+  & div.tv-demo-links-item,
   & a.tv-demo-links-item {
-    color: #1e40af;
+    color: inherit;
     text-decoration-color: rgba(30, 64, 175, 0.6);
     text-shadow: 0 0 12px rgba(30, 64, 175, 0.25);
 

--- a/src/demo/Demo.vue
+++ b/src/demo/Demo.vue
@@ -9,7 +9,7 @@ const Component = defineAsyncComponent(/* webpackChunkName: "Test" */() => impor
 </script>
 
 <template>
-  <tv-demo
+  <TvDemo
     :component="Component"
     :variants="demos"
     component-name="TvDemo"
@@ -17,7 +17,7 @@ const Component = defineAsyncComponent(/* webpackChunkName: "Test" */() => impor
     source-link="https://github.com/TODOvue/tv-demo"
     url-clone="https://github.com/TODOvue/tv-demo.git"
     is-dev-component
-    version="1.2.0"
-  ></tv-demo>
+    version="1.2.1"
+  />
 </template>
 


### PR DESCRIPTION
## [1.2.1] - 2025-11-21

### Fixed
- Fixed links color when the component use `hide-background` demo style.