### PR TITLE
Change base to deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `@todovue/tv-demo` will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.2.6] - 2025-12-16
+
+### Changed
+- Changed the `base` option in `vite.config.js` for website deployment to `/tv-demo/`.
+
 ## [1.2.5] - 2025-12-16
 
 ### Fixed
@@ -160,6 +165,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Integrated `vue-highlight-code` for live code display.
 - Responsive layout for desktop and mobile screens.
 
+[1.2.6]: https://github.com/TODOvue/tv-demo/pull/40/files
 [1.2.5]: https://github.com/TODOvue/tv-demo/pull/39/files
 [1.2.4]: https://github.com/TODOvue/tv-demo/pull/38/files
 [1.2.3]: https://github.com/TODOvue/tv-demo/pull/37/files

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Cristhian Daza
+Copyright (c) 2026 Cristhian Daza
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A flexible, framework-agnostic Vue 3 component catalog for demos, documentation,
 ![Last Commit](https://img.shields.io/github/last-commit/TODOvue/tv-demo)
 ![Stars](https://img.shields.io/github/stars/TODOvue/tv-demo?style=social)
 
-> Demo: https://tv-demo.netlify.app/
+> Demo: https://ui.todovue.blog/demo/
 
 ---
 ## Table of Contents

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "version": "1.2.5",
   "type": "module",
+  "homepage": "https://ui.todovue.blog/demo",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/TODOvue/tv-demo.git"

--- a/src/demo/Demo.vue
+++ b/src/demo/Demo.vue
@@ -17,7 +17,7 @@ const Component = defineAsyncComponent(/* webpackChunkName: "Test" */() => impor
     source-link="https://github.com/TODOvue/tv-demo"
     url-clone="https://github.com/TODOvue/tv-demo.git"
     is-dev-component
-    version="1.2.5"
+    version="1.2.6"
   />
 </template>
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,7 @@ import dts from "vite-plugin-dts";
 const isDemo = process.env.VITE_BUILD_TARGET === "demo";
 
 export default defineConfig({
+  base: isDemo ? './' : undefined,
   plugins: [
     vue(),
     dts({


### PR DESCRIPTION
## [1.2.6] - 2025-12-16

### Changed
- Changed the `base` option in `vite.config.js` for website deployment to `/tv-demo/`.