### PR TITLE
Changed props to correct 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [1.2.7] - 2025-12-16
 
 ### Changed
-- Se cambia el valor por defecto del `readmePath` y `changelogPath` a `'./'` para facilitar la configuración en proyectos monorepo.
-
-### Changed
-- Changed the `base` option in `vite.config.js` for website deployment to `/tv-demo/`.
+- Changed the default value of `readmePath` and `changelogPath` to `./` to simplify configuration in monorepo projects.
 
 ## [1.2.6] - 2025-12-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `@todovue/tv-demo` will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.2.7] - 2025-12-16
+
+### Changed
+- Se cambia el valor por defecto del `readmePath` y `changelogPath` a `'./'` para facilitar la configuración en proyectos monorepo.
+
+### Changed
+- Changed the `base` option in `vite.config.js` for website deployment to `/tv-demo/`.
+
 ## [1.2.6] - 2025-12-16
 
 ### Changed
@@ -165,6 +173,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Integrated `vue-highlight-code` for live code display.
 - Responsive layout for desktop and mobile screens.
 
+[1.2.7]: https://github.com/TODOvue/tv-demo/pull/41/files
 [1.2.6]: https://github.com/TODOvue/tv-demo/pull/40/files
 [1.2.5]: https://github.com/TODOvue/tv-demo/pull/39/files
 [1.2.4]: https://github.com/TODOvue/tv-demo/pull/38/files

--- a/src/components/TvDemo.vue
+++ b/src/components/TvDemo.vue
@@ -19,8 +19,8 @@ const props = defineProps({
   npmInstall: { type: String, default: null },
   isDevComponent: { type: Boolean, default: false },
   version: { type: String, default: '0.0.0' },
-  readmePath: { type: String, default: "/README.md" },
-  changelogPath: { type: String, default: "/CHANGELOG.md" },
+  readmePath: { type: String, default: "./README.md" },
+  changelogPath: { type: String, default: "./CHANGELOG.md" },
   showDocumentation: { type: Boolean, default: true },
   showChangelog: { type: Boolean, default: true },
 });

--- a/src/demo/Demo.vue
+++ b/src/demo/Demo.vue
@@ -17,7 +17,7 @@ const Component = defineAsyncComponent(/* webpackChunkName: "Test" */() => impor
     source-link="https://github.com/TODOvue/tv-demo"
     url-clone="https://github.com/TODOvue/tv-demo.git"
     is-dev-component
-    version="1.2.6"
+    version="1.2.7"
   />
 </template>
 


### PR DESCRIPTION
## [1.2.7] - 2025-12-16

### Changed
- Changed the default value of `readmePath` and `changelogPath` to `./` to simplify configuration in monorepo projects.